### PR TITLE
Fix type and null not allowed for array error. 

### DIFF
--- a/code/extensions/EditableMailChimpField.php
+++ b/code/extensions/EditableMailChimpField.php
@@ -235,7 +235,7 @@ class EditableMailChimpField extends EditableFormField
             $data = [
                 'email_address' => $emailaddress,
                 'status'        => 'subscribed',
-                'tags'          => null,
+                'tags'          => [],
                 'merge_fields' => $mergefields,
             ];
 

--- a/code/extensions/EditableMailChimpField.php
+++ b/code/extensions/EditableMailChimpField.php
@@ -142,7 +142,7 @@ class EditableMailChimpField extends EditableFormField
             "Root.Main",
             array(
                 LiteralField::create("MailChimpStart", "<h4>MailChimp Configuration</h4>")->setAttribute("disabled", $fieldsStatus),
-                DropdownField::create("ListID", 'Subscripers List', $this->getLists()->map("ListID", "Name"))
+                DropdownField::create("ListID", 'Subscribers List', $this->getLists()->map("ListID", "Name"))
                     ->setEmptyString("Choose a MailChimp List")
                     ->setAttribute("disabled", $fieldsStatus),
                 TextField::create("TagsToAssign", 'Tags To Assign')

--- a/code/extensions/EditableMailChimpField.php
+++ b/code/extensions/EditableMailChimpField.php
@@ -189,7 +189,7 @@ class EditableMailChimpField extends EditableFormField
         if ($this->FieldType == 'HiddenField') {
             $field = HiddenField::create($this->Name, $this->Title, 1);
         } else {
-            $field = CheckboxField::create($this->Name, $this->Title);
+            $field = CheckboxField::create($this->Name, $this->Title, $this->Default == 1 ? 1 : 0);
         }
 
         $this->doUpdateFormField($field);


### PR DESCRIPTION
A couple of small fixes:
1. Typo correction for subscripers -> subscribers.
2. On Silverstripe 5 PHP 8.1 I struck an error "Null not allowed for array" related to the tags field. 